### PR TITLE
Update the repository to https for maven 3.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,12 @@
     <repositories>
         <repository>
             <id>Vaadin Directory</id>
-            <url>http://maven.vaadin.com/vaadin-addons</url>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
         <!-- Repository needed for prerelease versions of Vaadin -->
         <repository>
             <id>Vaadin prereleases</id>
-            <url>http://maven.vaadin.com/vaadin-prereleases</url>
+            <url>https://maven.vaadin.com/vaadin-prereleases</url>
         </repository>
         <!-- The bintray repository contain webjars immediately after generation. If the webjar is available
              in Maven central, you do not need this repository -->


### PR DESCRIPTION
The new Maven version blocks http repositories for security reason.
There is a warning when build an application:
```
Downloading from maven-default-http-blocker: http://0.0.0.0/org/webjars/npm/mobile-drag-drop/maven-metadata.xml
[WARNING] Could not transfer metadata org.webjars.npm:mobile-drag-drop/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/): transfer failed for http://0.0.0.0/org/webjars/npm/mobile-drag-drop/maven-metadata.xml
[WARNING] org.webjars.npm:mobile-drag-drop/maven-metadata.xmlfailed to transfer from http://0.0.0.0/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of maven-default-http-blocker has elapsed or updates are forced. Original error: Could not transfer metadata org.webjars.npm:mobile-drag-drop/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/): transfer failed for http://0.0.0.0/org/webjars/npm/mobile-drag-drop/maven-metadata.xml
[WARNING] org.webjars.npm:mobile-drag-drop/maven-metadata.xmlfailed to transfer from http://0.0.0.0/ during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of maven-default-http-blocker has elapsed or updates are forced. Original error: Could not transfer metadata org.webjars.npm:mobile-drag-drop/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/): transfer failed for http://0.0.0.0/org/webjars/npm/mobile-drag-drop/maven-metadata.xml
```

Is it possible to update the addon?